### PR TITLE
Fix Http upgrade requests on node < 10

### DIFF
--- a/lib/BundlerServer.js
+++ b/lib/BundlerServer.js
@@ -9,6 +9,7 @@
   included in all copies or substantial portions of this Source Code Form.
 */
 const url = require('url');
+const { createServer: HTTPCreateServer, ServerResponse } = require('http');
 
 const open = require('opn');
 
@@ -25,7 +26,7 @@ class BundlerServer extends BundlerRouter {
     const { options } = this;
     /* eslint-disable global-require */
     const types = {
-      http: require('http').createServer,
+      http: HTTPCreateServer,
       https: require('https').createServer,
       http2: require('http2').createServer,
       http2Secure: require('http2').createSecureServer
@@ -95,6 +96,13 @@ class BundlerServer extends BundlerRouter {
     };
 
     this.listening = true;
+
+    // Node's HTTP server doesn't send upgrade requests
+    // through the normal callback(and thus your Koa middleware chain)
+    // on node version < 10
+    if (parseInt(process.versions.node, 10) < 10) {
+      server.on('upgrade', (req) => server.emit('request', req, new ServerResponse(req)));
+    }
 
     const protocol = secure ? 'https' : 'http';
     const address = server.address();


### PR DESCRIPTION
This PR contains:

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [X] no

If yes, please describe the breakage.

### Please Describe Your Changes

Add a fix to propagate upgrade request on the middleware chain for node version < 10

(Also to keep consistency between wps and bundler-serve)
